### PR TITLE
.less files: standardize on a two-space indent

### DIFF
--- a/Blitz_framework/LESS/base/reset.less
+++ b/Blitz_framework/LESS/base/reset.less
@@ -35,13 +35,13 @@ h1, h2, h3, h4, h5, h6, dt, pre {
 
 /* Following EPUB 3 spec by the letter (applies to RS but let’s make sure it is respected because we never know) */
 nav[epub|type~="toc"] ol {
-    list-style: none !important;
+  list-style: none !important;
 }
 
 /* [Opinionated] Default to prevent bloat in case linear="no" is rendered as linear="yes" */
 nav[epub|type~="landmarks"],
 nav[epub|type~="page-list"] {
-    display: none;   
+  display: none;
 }
 
 a, abbr, b, bdi, bdo, cite, code, data, del, dfn, em, i, ins, kbd, mark, q, rp, rt, rtc, ruby, s, samp, small, span, strong, sub, sup, time, var {

--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -68,7 +68,7 @@ h6 {
 }
 
 p {
-    .indent;
+  .indent;
 }
 
 .footnote {

--- a/Blitz_framework/LESS/extensions/media.less
+++ b/Blitz_framework/LESS/extensions/media.less
@@ -9,11 +9,11 @@ video {
 }
 
 canvas, iframe, svg, video {
-    width: auto;
-    max-width: 100%;
-    height: auto;
+  width: auto;
+  max-width: 100%;
+  height: auto;
 }
 
 svg {
-    .fit-contain;
+  .fit-contain;
 }

--- a/Blitz_framework/LESS/extensions/table.less
+++ b/Blitz_framework/LESS/extensions/table.less
@@ -55,5 +55,5 @@ td {
 }
 
 .table-fixed {
-    table-layout: fixed;   
+  table-layout: fixed;
 }

--- a/Blitz_framework/LESS/reference/enhancements.less
+++ b/Blitz_framework/LESS/reference/enhancements.less
@@ -1,206 +1,206 @@
 // EPUB3 Utilities
 
 
-    // Layout
+// Layout
 
 .drop-cap() {
 /* Can’t be used as a class, you must use :first-letter */
-    margin: 1em 0.25em 0 0; /* iOS 9 fix */
-    .initial-letter();
+  margin: 1em 0.25em 0 0; /* iOS 9 fix */
+  .initial-letter();
 }
 
 .flex {
-    display: -webkit-flex;
-    display: flex;
+  display: -webkit-flex;
+  display: flex;
 }
 
 .flex-col {
-    -ms-flex-direction: column;
-    -webkit-flex-direction: column;
-    flex-direction: column;
+  -ms-flex-direction: column;
+  -webkit-flex-direction: column;
+  flex-direction: column;
 }
 
 .flex-wrap {
-    -ms-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .flex-start {
-    -webkit-justify-content: flex-start;
-    justify-content: flex-start; 
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
 }
 
 .flex-center {
-    -webkit-justify-content: center;
-    justify-content: center; 
+  -webkit-justify-content: center;
+  justify-content: center;
 }
 
 .flex-end {
-    -webkit-justify-content: flex-end;
-    justify-content: flex-end; 
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
 }
 
 .flex-between {
-    -webkit-justify-content: space-between;
-    justify-content: space-between;  
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
 }
 
 .flex-around {
-    -webkit-justify-content: space-around;
-    justify-content: space-around;   
+  -webkit-justify-content: space-around;
+  justify-content: space-around;
 }
 
-    // Vertical align
+// Vertical align
     
 .valign-center {
-    min-height: 95vh;
-    .flex;
-    .flex-col;
-    .flex-center;
+  min-height: 95vh;
+  .flex;
+  .flex-col;
+  .flex-center;
 }
 
 .valign-bottom {
-    min-height: 95vh;
-    .flex;
-    .flex-col;
-    .flex-end;
+  min-height: 95vh;
+  .flex;
+  .flex-col;
+  .flex-end;
 }
 
 .valign-between {
-    min-height: 95vh;
-    .flex;
-    .flex-col;
-    .flex-between;
+  min-height: 95vh;
+  .flex;
+  .flex-col;
+  .flex-between;
 }
 
 .valign-around {
-    min-height: 95vh;
-    .flex;
-    .flex-col;
-    .flex-around;
+  min-height: 95vh;
+  .flex;
+  .flex-col;
+  .flex-around;
 }
 
-    // Object sizing
-    
+// Object sizing
+   
 .fit-contain {
-  object-fit: contain;   
+  object-fit: contain;
 }
 
 .fit-fill {
-  object-fit: fill;   
+  object-fit: fill;
 }
 
 .fit-cover {
-  object-fit: cover;   
+  object-fit: cover;
 }
 
 .fit-scale {
-  object-fit: scale-down;   
+  object-fit: scale-down;
 }
 
 .fit-none {
-  object-fit: none;   
+  object-fit: none;
 }
 
 .bg-contain {
-  background-size: contain;   
+  background-size: contain;
 }
 
 .bg-cover {
   background-size: cover;
 }
 
-    // OTF
+// OTF
   
 .kern {
-    font-kerning: normal;
+  font-kerning: normal;
 }
 
 .no-kern {
-    font-kerning: none;
+  font-kerning: none;
 }
 
 .clig {
-    -webkit-font-variant-ligatures: common-ligatures;
-    font-variant-ligatures: common-ligatures;
+  -webkit-font-variant-ligatures: common-ligatures;
+  font-variant-ligatures: common-ligatures;
 }
 
 .dlig {
-    -webkit-font-variant-ligatures: discretionary-ligatures;
-    font-variant-ligatures: discretionary-ligatures;
+  -webkit-font-variant-ligatures: discretionary-ligatures;
+  font-variant-ligatures: discretionary-ligatures;
 }
 
 .no-liga {
-    -webkit-font-variant-ligatures: no-common-ligatures;
-    font-variant-ligatures: no-common-ligatures;
+  -webkit-font-variant-ligatures: no-common-ligatures;
+  font-variant-ligatures: no-common-ligatures;
 }
 
 .true-sc {
-    font-variant-caps: small-caps;
+  font-variant-caps: small-caps;
 }
 
 .c2sc {
-    font-variant-caps: all-small-caps;
+  font-variant-caps: all-small-caps;
 }
 
 .titling {
-    font-variant-caps: titling-caps;
+  font-variant-caps: titling-caps;
 }
 
 .calt {
-    -webkit-font-variant-ligatures: contextual;
-    font-variant-ligatures: contextual;
+  -webkit-font-variant-ligatures: contextual;
+  font-variant-ligatures: contextual;
 }
 
 .lnum {
-    font-variant-numeric: lining-nums;
+  font-variant-numeric: lining-nums;
 }
 
 .pnum {
-    font-variant-numeric: proportional-nums;
+  font-variant-numeric: proportional-nums;
 }
 
 .onum {
-    font-variant-numeric: oldstyle-nums;
+  font-variant-numeric: oldstyle-nums;
 }
 
 .tnum {
-    font-variant-numeric: tabular-nums;
+  font-variant-numeric: tabular-nums;
 }
 
 .lnum-tnum {
-    font-variant-numeric: lining-nums tabular-nums;
+  font-variant-numeric: lining-nums tabular-nums;
 }
 
 .lnum-pnum {
-    font-variant-numeric: lining-nums proportional-nums;
+  font-variant-numeric: lining-nums proportional-nums;
 }
 
 .onum-pnum {
-    font-variant-numeric: oldstyle-nums proportional-nums;
+  font-variant-numeric: oldstyle-nums proportional-nums;
 }
 
 .slash {
-    font-variant-numeric: slashed-zero;
+  font-variant-numeric: slashed-zero;
 }
 
 .frac {
-    font-variant-numeric: diagonal-fractions;
+  font-variant-numeric: diagonal-fractions;
 }
 
 .stacked {
-    font-variant-numeric: stacked-fractions;
+  font-variant-numeric: stacked-fractions;
 }
 
 .ordinal {
-    font-variant-numeric: ordinal;
+  font-variant-numeric: ordinal;
 }
 
 .sups {
-    font-variant-position: super;
+  font-variant-position: super;
 }
 
 .subs {
-    font-variant-position: sub;
+  font-variant-position: sub;
 }

--- a/Blitz_framework/LESS/reference/hyphens.less
+++ b/Blitz_framework/LESS/reference/hyphens.less
@@ -14,43 +14,43 @@
 }
 
 .hyphens-char(@hyphens-char: auto) {
-    -ms-hyphenate-character: @hyphens-char;
-    -moz-hyphenate-character: @hyphens-char;
-    -webkit-hyphenate-character: @hyphens-char;
-    hyphenate-character: @hyphens-char;
+  -ms-hyphenate-character: @hyphens-char;
+  -moz-hyphenate-character: @hyphens-char;
+  -webkit-hyphenate-character: @hyphens-char;
+  hyphenate-character: @hyphens-char;
 }
 
 /* 2 is the default for hyphenate-lines in case an hyphenated word
 happens to be displayed at the end of the line (2 + 1 = 3) */
 .hyphens-lines(@hyphens-lines: 2) {
-    -ms-hyphenate-limit-lines: @hyphens-lines;
-    -moz-hyphenate-limit-lines: @hyphens-lines;
-    -webkit-hyphenate-limit-lines: @hyphens-lines;
-    hyphenate-limit-lines: @hyphens-lines;
+  -ms-hyphenate-limit-lines: @hyphens-lines;
+  -moz-hyphenate-limit-lines: @hyphens-lines;
+  -webkit-hyphenate-limit-lines: @hyphens-lines;
+  hyphenate-limit-lines: @hyphens-lines;
 }
 
 /* No support except Trident (Windows) and Webkit (old deprecated syntax) */
 .hyphens-division(@hyphens-chars-min: 6, @hyphens-chars-before: 3, @hyphens-chars-after: 2) {
-    -ms-hyphenate-limit-chars: @hyphens-chars-min @hyphens-chars-before @hyphens-chars-after;
-    -moz-hyphenate-limit-chars: @hyphens-chars-min @hyphens-chars-before @hyphens-chars-after;
-    -webkit-hyphenate-limit-before: @hyphens-chars-before;
-    -webkit-hyphenate-limit-after: @hyphens-chars-after;
-    hyphenate-limit-chars: @hyphens-chars-min @hyphens-chars-before @hyphens-chars-after; 
+  -ms-hyphenate-limit-chars: @hyphens-chars-min @hyphens-chars-before @hyphens-chars-after;
+  -moz-hyphenate-limit-chars: @hyphens-chars-min @hyphens-chars-before @hyphens-chars-after;
+  -webkit-hyphenate-limit-before: @hyphens-chars-before;
+  -webkit-hyphenate-limit-after: @hyphens-chars-after;
+  hyphenate-limit-chars: @hyphens-chars-min @hyphens-chars-before @hyphens-chars-after;
 }
 
 /* No support except Trident (Windows) */
 .hyphens-zone(@hyphens-zone: 10%) {
-    -ms-hyphenate-limit-zone: @hyphens-zone;
-    -moz-hyphenate-limit-zone: @hyphens-zone;
-    -webkit-hyphenate-limit-zone: @hyphens-zone;
-    hyphenate-limit-zone: @hyphens-zone;  
+  -ms-hyphenate-limit-zone: @hyphens-zone;
+  -moz-hyphenate-limit-zone: @hyphens-zone;
+  -webkit-hyphenate-limit-zone: @hyphens-zone;
+  hyphenate-limit-zone: @hyphens-zone;
 }
 
 .hyphens-limit(@hyphens-last: always) {
-    -ms-hyphenate-limit-last: @hyphens-last;
-    -moz-hyphenate-limit-last: @hyphens-last;
-    -webkit-hyphenate-limit-last: @hyphens-last;
-    hyphenate-limit-last: @hyphens-last;
+  -ms-hyphenate-limit-last: @hyphens-last;
+  -moz-hyphenate-limit-last: @hyphens-last;
+  -webkit-hyphenate-limit-last: @hyphens-last;
+  hyphenate-limit-last: @hyphens-last;
 }
 
 // CSS Output
@@ -62,7 +62,7 @@ happens to be displayed at the end of the line (2 + 1 = 3) */
   -moz-hyphens: none;
   -webkit-hyphens: none;
   -epub-hyphens: none;
-  hyphens: none; 
+  hyphens: none;
 }
 
 /* To use in combination with &#173; (soft-hyphen) */
@@ -72,7 +72,7 @@ happens to be displayed at the end of the line (2 + 1 = 3) */
   -moz-hyphens: manual;
   -webkit-hyphens: manual;
   -epub-hyphens: manual;
-  hyphens: manual; 
+  hyphens: manual;
 }
 
 .hyphenate {

--- a/Blitz_framework/LESS/reference/i18n.less
+++ b/Blitz_framework/LESS/reference/i18n.less
@@ -1,6 +1,6 @@
 /* INTERNATIONALIZATION */
 
-  /* Layout */
+/* Layout */
 
 .horizontal-tb {
   -ms-writing-mode: lr-tb;
@@ -41,9 +41,9 @@
   text-orientation: sideways;
 }
 
-  /* Note: for direction, use the dir attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir */
+/* Note: for direction, use the dir attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir */
 
-  /* Typography */
+/* Typography */
 
 .line-break-auto {
   -ms-line-break: auto;
@@ -125,7 +125,7 @@
   text-transform: full-size-kana;
 }
 
-  /* Font Families (class = language code) */
+/* Font Families (class = language code) */
 
 .am {
   font-family: Kefa, Nyala, Roboto, Noto, "Noto Sans Ethiopic", serif;

--- a/Blitz_framework/LESS/reference/mixins.less
+++ b/Blitz_framework/LESS/reference/mixins.less
@@ -3,107 +3,107 @@
 // Centering an element based on its width
 
 .width-center(@elWidth) {
-    width: @elWidth + 0%;
-    margin-left: ((100 - @elWidth) / 2) + 0%;
+  width: @elWidth + 0%;
+  margin-left: ((100 - @elWidth) / 2) + 0%;
 }
 
 // Border radius for boxes 
 
 .border-radius(@radius: 5px) {
-	border-radius: @radius;
+  border-radius: @radius;
 }
 
 // Linear-gradient to color and back to origin
 
 .linear-gradient(@origin: left, @start: #f0f0f0, @stop: #8c8b8b) {
-	background-color: @stop;    /* fallback if linear-gradient is not supported */
-    background-image: -webkit-linear-gradient(@origin, @start, @stop, @start);
-    background-image: linear-gradient(@origin, @start, @stop, @start); 
+  background-color: @stop;    /* fallback if linear-gradient is not supported */
+  background-image: -webkit-linear-gradient(@origin, @start, @stop, @start);
+  background-image: linear-gradient(@origin, @start, @stop, @start);
 }
 
 // Subtle Color Palette
 // Usage: .generate-subtle-palette(#537F84); in custom
 
 .generate-subtle-palette(@baseColor) {
-    .subtle-1 {
-        color: lighten(spin(@baseColor, 10), 20%);
-    }
-    .subtle-2 {
-        color: lighten(spin(@baseColor, 5), 10%);
-    }
-    .subtle-3 {
-        color: @baseColor;
-    }
-    .subtle-4 {
-        color: darken(spin(@baseColor, -5), 10%);
-    }
-    .subtle-5 {
-        color: darken(spin(@baseColor, -10), 20%);
-    }
+  .subtle-1 {
+    color: lighten(spin(@baseColor, 10), 20%);
+  }
+  .subtle-2 {
+    color: lighten(spin(@baseColor, 5), 10%);
+  }
+  .subtle-3 {
+    color: @baseColor;
+  }
+  .subtle-4 {
+    color: darken(spin(@baseColor, -5), 10%);
+  }
+  .subtle-5 {
+    color: darken(spin(@baseColor, -10), 20%);
+  }
 }
 
 // Complementary Color Palette
 // Usage: .generate-comp-palette(#537F84); in custom
 
 .generate-comp-palette(@baseColor) {
-    .comp-1 {
-        color: lighten(@baseColor, 30%);
-    }
-    .comp-2 {
-        color: lighten(@baseColor, 15%);;
-    }
-    .comp-3 {
-        color: @baseColor;
-    }
-    .comp-4 {
-        color: spin(@baseColor, 180);
-    }
-    .comp-5 {
-        color: darken(spin(@baseColor, 180), 5%);
-    }
+  .comp-1 {
+    color: lighten(@baseColor, 30%);
+  }
+  .comp-2 {
+    color: lighten(@baseColor, 15%);;
+  }
+  .comp-3 {
+    color: @baseColor;
+  }
+  .comp-4 {
+    color: spin(@baseColor, 180);
+  }
+  .comp-5 {
+    color: darken(spin(@baseColor, 180), 5%);
+  }
 }
 
 // Creating cols
 
 .generate-columns(@n, @i: 1) when (@i =< @n) {      // Useful for image grids
-    .col-@{i} {
-        width: (@i * 100% / @n);   
-    }
-    .generate-columns(@n, (@i + 1));
+  .col-@{i} {
+    width: (@i * 100% / @n);
+  }
+  .generate-columns(@n, (@i + 1));
 }
 
 // Progressive enhancements
   
 .initial-letter(@size : 3, @sink : 3) {
-    -webkit-initial-letter: @size @sink;
-    initial-letter: @size @sink;    
+  -webkit-initial-letter: @size @sink;
+  initial-letter: @size @sink;
 }
 
 .flex-base(@grow, @shrink, @basis) {
-    -webkit-flex: @grow @shrink @basis;
-    flex: @grow @shrink @basis;
+  -webkit-flex: @grow @shrink @basis;
+  flex: @grow @shrink @basis;
 }
 
 .reflowable-height(@img : 98vh, @caption : 3em, @min : 300px, @max : 1400px) {
-    min-height: @min;
-    height: -webkit-calc(~"@{img} - @{caption}");
-    height: calc(~"@{img} - @{caption}");
-    max-height: @max !important;
+  min-height: @min;
+  height: -webkit-calc(~"@{img} - @{caption}");
+  height: calc(~"@{img} - @{caption}");
+  max-height: @max !important;
 }
 
 .background-size(@w, @h) {
-    background-size: @w @h;   
+  background-size: @w @h;
 }
 
 .background-position(@x, @y) {
-    background-position: @x @y;   
+  background-position: @x @y;
 }
 
 .text-align-last(@align : center) {
-    text-align-last: @align;   
+  text-align-last: @align;
 }
 
 .calc(@prop, @val1, @operator : "+", @val2) {
-    @{prop}: -webkit-calc(~"@{val1} @{operator} @{val2}");
-    @{prop}: calc(~"@{val1} @{operator} @{val2}");
+  @{prop}: -webkit-calc(~"@{val1} @{operator} @{val2}");
+  @{prop}: calc(~"@{val1} @{operator} @{val2}");
 };

--- a/Blitz_framework/LESS/reference/overrides.less
+++ b/Blitz_framework/LESS/reference/overrides.less
@@ -2,11 +2,11 @@
 
 
 .override-italic {
-    font-style: normal;   
+  font-style: normal;
 }
 
 .override-iBooks-links(@overrideColor: inherit) {
-    -webkit-text-fill-color: @overrideColor;   /* iBooks override (iOS 9 + El Capitan in night mode) */
+  -webkit-text-fill-color: @overrideColor;   /* iBooks override (iOS 9 + El Capitan in night mode) */
 }
 
 // Ideally, you should not use that 
@@ -27,13 +27,13 @@
 
 .override-ul-type(@ulType: ~"\2014") {    // ISO value between quotes please, because Google Play Books
   ul li:nth-child(n+1) {
-	list-style-type: none;      /* won’t disable in RS which don’t support :nth-child */
+    list-style-type: none;      /* won’t disable in RS which don’t support :nth-child */
   }
   ul li:nth-child(n+1):before {
     /* Extra-cautious selector in case some epub2 RS supports :before but not :nth-child */
-	content: "@{ulType}";
-	position: relative;
-	left: -0.35em;
+    content: "@{ulType}";
+    position: relative;
+    left: -0.35em;
   }   
 }
 
@@ -42,12 +42,12 @@
     counter-reset: increment-list;   
   }
   ol li:nth-child(n+1) {
-	list-style-type: none;
+    list-style-type: none;
   }
   ol li:nth-child(n+1):before {
-	content: counter(increment-list, @ol-type);
-	counter-increment: increment-list;
-	position: relative;
-	left: -0.35em;
+    content: counter(increment-list, @ol-type);
+    counter-increment: increment-list;
+    position: relative;
+    left: -0.35em;
   }   
 }

--- a/Blitz_framework/LESS/utils/utilities.less
+++ b/Blitz_framework/LESS/utils/utilities.less
@@ -1,6 +1,6 @@
 /* UTILITIES */
 
-    /* Display */
+/* Display */
 
 .block {
   display: block;
@@ -24,7 +24,7 @@
 }   
 */
 
-    /* Clearings */
+/* Clearings */
     
 .clear {              /* may be useful if an element is floating in a container */
   clear: both;
@@ -38,7 +38,7 @@
   clear: right;   
 }
 
-    /* Bordered content */
+/* Bordered content */
 
 .boxed {
   border: ((@border-width / @body-font-size) + 0em) @border-style @border-color; /* Current color = color of text (inverted in night mode) */
@@ -46,7 +46,7 @@
   padding: ((@computed-padding / 2) + 0em);
 }
 
-    /* Margins */
+/* Margins */
 
 .no-margin {
   margin: 0;
@@ -188,7 +188,7 @@
   margin-right: (@step * 3);   
 }
 
-    /* Font-stacks */
+/* Font-stacks */
 
 .sans {                     /* Typical usage: headings */
   font-family: sans-serif;
@@ -222,7 +222,7 @@
   font-family: Athelas, Literata, Bookerly, "Merriweather Serif", Malabar, "BN Malabar", Georgia, "Droid Serif", serif;
 }
 
-    /* Text align */
+/* Text align */
     
 .justified {                /* Designed as a class for body — We don't enforce as user setting > author */
   text-align: justify;
@@ -243,7 +243,7 @@
   text-align: right;
 }
 
-    /* Indents */
+/* Indents */
     
 .indent {
     text-indent: @base-fs;  
@@ -297,7 +297,7 @@
   .fs(4);
 }
 
-    /* Font styles */
+/* Font styles */
 
 .bold {               /* Don't use that with span if b or strong can be used */
   font-weight: bold;


### PR DESCRIPTION
Currently, in the .less files, three types of indents are used.

* two-space indent
* four-space indent
* tab indent

This PR standardizes the indent to be a two-space indent.