### PR TITLE
text-emphasis: add mixin and complete set of text-emphasis styles

### DIFF
--- a/Blitz_framework/LESS/reference/i18n.less
+++ b/Blitz_framework/LESS/reference/i18n.less
@@ -96,16 +96,44 @@
   hanging-punctuation: last allow-end;
 }
 
-.emphasis-sesame {
-  -webkit-text-emphasis-style: sesame;
-  -epub-text-emphasis-style: sesame;
-  text-emphasis-style: sesame;
+.emphasis-filled-sesame {
+  .text-emphasis(filled sesame);
 }
 
-.emphasis-dots {
-  -webkit-text-emphasis-style: dot;
-  -epub-text-emphasis-style: dot;
-  text-emphasis-style: dot;
+.emphasis-open-sesame {
+  .text-emphasis(open sesame);
+}
+
+.emphasis-filled-dot {
+  .text-emphasis(filled dot);
+}
+
+.emphasis-open-dot {
+  .text-emphasis(open dot);
+}
+
+.emphasis-filled-triangle {
+  .text-emphasis(filled triangle);
+}
+
+.emphasis-open-triangle {
+  .text-emphasis(open triangle);
+}
+
+.emphasis-filled-circle {
+  .text-emphasis(filled circle);
+}
+
+.emphasis-open-circle {
+  .text-emphasis(open circle);
+}
+
+.emphasis-filled-double-circle {
+  .text-emphasis(filled double circle);
+}
+
+.emphasis-open-double-circle {
+  .text-emphasis(open double circle);
 }
 
 .tate-chu-yoko {

--- a/Blitz_framework/LESS/reference/mixins.less
+++ b/Blitz_framework/LESS/reference/mixins.less
@@ -107,3 +107,16 @@
   @{prop}: -webkit-calc(~"@{val1} @{operator} @{val2}");
   @{prop}: calc(~"@{val1} @{operator} @{val2}");
 };
+
+// i18n
+
+.text-emphasis(@emphasis-style : filled sesame) {
+  // Available arguments: filled dot, open dot, filled circle, open circle,
+  // filled double circle, open double-circle, filled triangle, open triangle,
+  // filled sesame, open sesame
+  text-emphasis: @emphasis-style;
+  text-emphasis-style: @emphasis-style;
+  -webkit-text-emphasis-style: @emphasis-style;
+  font-style: normal !important; // Need to override italics/bold because this is an alternative emphasis.
+  font-weight: normal !important;
+}


### PR DESCRIPTION
This PR adds a complete set of text-emphasis combinations based on https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis.

To make this easier, I made a mixin.  The mixin defaults to filled sesame, which is the most common type of emphasis in Japanese, which is the source language for this type of emphasis.

Because this type of emphasis in Japanese is used instead of bold/italics, the mixin forcibly resets bold/italics.