### PR TITLE
variables: add header font-family variable

### DIFF
--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -15,6 +15,10 @@ h1, h2, h3, h4, h5, h6, dt, hr {
   .no-break-after;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: @header-font-family;
+}
+
 h1 {
   .rhythm(3, 0, 2);
 

--- a/Blitz_framework/LESS/core/variables.less
+++ b/Blitz_framework/LESS/core/variables.less
@@ -6,6 +6,7 @@
 // Typo
 @body-font-size : 16;           // PX | default = 16 //
 @body-line-height : 1.5;        // Ratio //
+@header-font-family: inherit;   // Set to give the headers a different look from the main text.
 
 // Rhythm
 @major-third: 1.25;


### PR DESCRIPTION
I think it would be nice to have a variable to allow the header font family to be set easily in one place, as many books use a different font for the header vs. the body text (e.g., sans serif vs. serif).