### PR TITLE
 add header classes to allow paragraphs and other elements to be treated 2ecc79a  as headers

### DIFF
--- a/Blitz_framework/LESS/base/reset.less
+++ b/Blitz_framework/LESS/base/reset.less
@@ -29,7 +29,7 @@ article, aside, figure, figcaption, footer, header, main, nav, section {
 }
 
 /* [Opinionated] Default to prevent RS from justifying all of these! */
-h1, h2, h3, h4, h5, h6, dt, pre {
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, dt, pre {
   text-align: left;
 }
 

--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -15,6 +15,10 @@ h1, h2, h3, h4, h5, h6, dt, hr {
   .no-break-after;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: @header-font-family;
+}
+
 h1 {
   .rhythm(3, 0, 2);
 

--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -10,16 +10,16 @@ table, caption, th, td,
   .disable-hyphens;
 }
 
-h1, h2, h3, h4, h5, h6, dt, hr {
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6, dt, hr {
   .no-break-inside;
   .no-break-after;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: @header-font-family;
 }
 
-h1 {
+h1, .h1 {
   .rhythm(3, 0, 2);
 
   @media @kf8 {
@@ -32,7 +32,7 @@ h1 {
   }
 }
 
-h2 {
+h2, .h2 {
   .rhythm(2, 2, 1);
 
   @media @kf8 {
@@ -45,7 +45,7 @@ h2 {
   }
 }
 
-h3 {
+h3, .h3 {
   .rhythm(1, 1, 1);
 
   @media @mobi7 {
@@ -54,7 +54,7 @@ h3 {
   }
 }
 
-h4 {
+h4, .h4 {
   .rhythm(0, 1, 0);
 
   @media @mobi7 {
@@ -63,11 +63,11 @@ h4 {
   }
 }
 
-h5 {
+h5, .h5 {
 /* Styles */    
 }
 
-h6 {
+h6, .h6 {
 /* Styles */    
 }
 

--- a/Blitz_framework/LESS/core/variables.less
+++ b/Blitz_framework/LESS/core/variables.less
@@ -6,6 +6,7 @@
 // Typo
 @body-font-size : 16;           // PX | default = 16 //
 @body-line-height : 1.5;        // Ratio //
+@header-font-family: inherit;   // Set to give the headers a different look from the main text.
 
 // Rhythm
 @major-third: 1.25;


### PR DESCRIPTION
This PR adds .h1 - .h6 as utility classes for making paragraphs and other elements function as headers.  I'm making this PR separate from the header-variable PR because it could be argued that this is a bad idea; if text is a header, it should be tagged as a header, not as a paragraph.

However, some older readers have trouble spacing headers but can space paragraphs properly, so this is a hack for handling those readers.

I'm presenting this here for discussion; feel free to close it if it doesn't match the design philosophy of the project.