### PR TITLE
add asterism-path variable to allow easy configuration in less

### DIFF
--- a/Blitz_framework/LESS/core/variables.less
+++ b/Blitz_framework/LESS/core/variables.less
@@ -15,6 +15,9 @@
 @unison: 1;
 @scale-factor : @major-second;  // The idea is that you can redefine it for media queries if needed
 
+// Paths
+@asterism-path : "../Images/asterism.svg"; // Must be set correctly if using extensions/rules.less
+
 // Horizontal grid
 @step : 5%;         // Should be used for horizontal margins (won’t reflow like em)
 

--- a/Blitz_framework/LESS/extensions/rules.less
+++ b/Blitz_framework/LESS/extensions/rules.less
@@ -34,7 +34,7 @@ hr.asterism {
   height: @base-margin;
   text-indent: 0;
   text-align: center;
-  background: transparent url("../Images/asterism.svg") no-repeat center;   /* Change url if you put asterism in a folder */
+  background: transparent url(@asterism-path) no-repeat center;   /* Change url if you put asterism in a folder */
   background-size: 2.5em 1.25em;    /* RMSDK doesn't support -> won't scale but SVG viewport is OK for a wide range of font-sizes */
   overflow: hidden;   /* Fixes legacy RMSDK bug when contents before hr are invisible */
   opacity: 0.7;   /* Better border color match in night mode (less disruptive) */


### PR DESCRIPTION
Many ebooks have their own structures for assets like SVGs, so I think the path for asterism.svg should be easier to configure-- especially because a broken path will cause epubcheck to fail.

 I think it would be nice if all of the most common things one might want to change could be found in variables.less.

