### PR TITLE
Toc list style for Kindle

### DIFF
--- a/Blitz_framework/LESS/base/reset.less
+++ b/Blitz_framework/LESS/base/reset.less
@@ -39,8 +39,10 @@ nav[epub|type~="toc"] ol {
 }
 
 /* Kindle does not follow the EPUB 3 spec. */
-nav ol {
-  list-style-type: none !important;
+@media amzn-mobi, amzn-kf8 {
+  nav ol {
+    list-style-type: none !important;
+  }
 }
 
 /* [Opinionated] Default to prevent bloat in case linear="no" is rendered as linear="yes" */

--- a/Blitz_framework/LESS/base/reset.less
+++ b/Blitz_framework/LESS/base/reset.less
@@ -39,7 +39,7 @@ nav[epub|type~="toc"] ol {
 }
 
 /* Kindle does not follow the EPUB 3 spec. */
-@media amzn-mobi, amzn-kf8 {
+@media @kf8, @mobi7 {
   nav ol {
     list-style-type: none !important;
   }

--- a/Blitz_framework/LESS/base/reset.less
+++ b/Blitz_framework/LESS/base/reset.less
@@ -38,6 +38,11 @@ nav[epub|type~="toc"] ol {
   list-style: none !important;
 }
 
+/* Kindle does not follow the EPUB 3 spec. */
+nav ol {
+  list-style-type: none !important;
+}
+
 /* [Opinionated] Default to prevent bloat in case linear="no" is rendered as linear="yes" */
 nav[epub|type~="landmarks"],
 nav[epub|type~="page-list"] {

--- a/Blitz_framework/LESS/blitz-reset.less
+++ b/Blitz_framework/LESS/blitz-reset.less
@@ -3,4 +3,5 @@
     Codename: Armagideon Time
     License: MIT (https://opensource.org/licenses/MIT)   */
 
+@import 'core/kindle-queries';
 @import 'base/reset';


### PR DESCRIPTION
My testing indicates that Kindle does not follow the EPUB3 spec, so the nav ol reset doesn't work for Kindle devices.

This adds a media query for Kindle devices to force the epub reset on Kindle as well.  To use variables in media queries, I had to update reset.less.

Testing: Kindle Previewer (3.34 for MacOS), Kindle for iOS (AZK sideloading, latest version)