### PR TITLE
Add link-color as a variable for convenience

### DIFF
--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -109,8 +109,8 @@ address {
 a {
   .underline;           /* Note: KF8 will force this value unless you use "el.class a" */
   font-weight: bold;
-  color: @primary-color;
-  .override-iBooks-links(@primary-color);   /* inherit = text color */
+  color: @link-color;
+  .override-iBooks-links(@link-color);   /* inherit = text color */
 }
 
 abbr {

--- a/Blitz_framework/LESS/core/variables.less
+++ b/Blitz_framework/LESS/core/variables.less
@@ -21,6 +21,7 @@
 // Colors
 @primary-color : inherit;
 @secondary-color : inherit;     // inherit = text-color (comes handy when trying to get around night modes)
+@link-color : @primary-color;
 
 // Decorations
 @border-width : 1;


### PR DESCRIPTION
Setting links to the primary color is a good default but sometimes links need to be colored (e.g., blue).  Adding a variable to do so will make this easier.