### PR TITLE
i18n: set typography for ruby text

### DIFF
--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -177,3 +177,11 @@ sup {
     font-size: x-small;
   }
 }
+
+/* i18n */
+
+/* Ruby text */
+rt {
+  font-size: 50%; /* Line-height may need to be adjusted to fit ruby text. */
+  text-transform: full-size-kana; /* Increases the legibility of Japanese ruby characters. */
+}

--- a/Blitz_framework/LESS/reference/i18n.less
+++ b/Blitz_framework/LESS/reference/i18n.less
@@ -149,10 +149,6 @@
   text-transform: full-width;
 }
 
-.full-size-kana-transform {
-  text-transform: full-size-kana;
-}
-
 /* Font Families (class = language code) */
 
 .am {


### PR DESCRIPTION
There is currently no typography setting for ruby text, which is normally displayed at 50% font size.

This PR specifies the standard font size. It also removes the "text transform: full-size-kana" class and applies it to the rt tag, because that is the only reason the "full-size-kana" property exists.  (See here: https://github.com/w3c/csswg-drafts/issues/3143)

Because extensions/i18n.less is included as a reference only, instead of adding the rt tag there, I added it to base/typo.less.