### PR TITLE
Language families should automatically apply to body, p, and span elements

### DIFF
--- a/Blitz_framework/LESS/reference/i18n.less
+++ b/Blitz_framework/LESS/reference/i18n.less
@@ -149,53 +149,53 @@
   text-transform: full-width;
 }
 
-/* Font Families (class = language code) */
+/* Font Families (class = language code or body/p with lang attribute set) */
 
-.am {
+.am, body:lang(am), p:lang(am), span:lang(am) {
   font-family: @am;
 }
 
-.ar {
+.ar, body:lang(ar), p:lang(ar), span:lang(ar) {
   font-family: @ar;
 }
 
-.bn {
+.bn, body:lang(bn), p:lang(bn), span:lang(bn) {
   font-family: @bn;
 }
 
-.bo {
+.bo, body:lang(bo), p:lang(bo), span:lang(bo) {
   font-family: @bo;
 }
 
-.chr {
+.chr, body:lang(chr), p:lang(chr), span:lang(chr) {
   font-family: @chr;
 }
 
-.fa {
+.fa, body:lang(fa), p:lang(fa), span:lang(fa) {
   font-family: @fa;
 }
 
-.gu {
+.gu, body:lang(gu), p:lang(gu), span:lang(gu) {
   font-family: @gu;
 }
 
-.he {
+.he, body:lang(he), p:lang(he), span:lang(he) {
   font-family: @he;
 }
 
-.hi {
+.hi, body:lang(hi), p:lang(hi), span:lang(hi) {
   font-family: @hi;
 }
 
-.hy {
+.hy, body:lang(hy), p:lang(hy), span:lang(hy) {
   font-family: @hy;
 }
 
-.iu {
+.iu, body:lang(iu), p:lang(iu), span:lang(iu) {
   font-family: @iu;
 }
 
-.ja {
+.ja, body:lang(ja), p:lang(ja), span:lang(ja) {
   font-family: @ja; 
 }
 
@@ -215,59 +215,59 @@
   font-family: @ja-sans-serif-vertical;
 }
 
-.km {
+.km, body:lang(km), p:lang(km), span:lang(km) {
   font-family: @km;
 }
 
-.kn {
+.kn, body:lang(kn), p:lang(kn), span:lang(kn) {
   font-family: @kn;
 }
 
-.ko {
+.ko, body:lang(ko), p:lang(ko), span:lang(ko) {
   font-family: @ko;
 }
 
-.lo {
+.lo, body:lang(lo), p:lang(lo), span:lang(lo) {
   font-family: @lo;
 }
 
-.ml {
+.ml, body:lang(ml), p:lang(ml), span:lang(ml) {
   font-family: @ml;
 }
 
-.or {
+.or, body:lang(or), p:lang(or), span:lang(or) {
   font-family: @or;
 }
 
-.pa {
+.pa, body:lang(pa), p:lang(pa), span:lang(pa) {
   font-family: @pa;
 }
 
-.si {
+.si, body:lang(si), p:lang(si), span:lang(si) {
   font-family: @si;
 }
 
-.ta {
+.ta, body:lang(ta), p:lang(ta), span:lang(ta) {
   font-family: @ta;
 }
 
-.te {
+.te, body:lang(te), p:lang(te), span:lang(te) {
   font-family: @te;
 }
 
-.th {
+.th, body:lang(th), p:lang(th), span:lang(th) {
   font-family: @th;
 }
 
-.zh {
+.zh, body:lang(zh), p:lang(zh), span:lang(zh) {
   font-family: @zh;
 }
 
 .zh-Hant,
-.zh-TW {
+.zh-TW, body:lang(zh-TW), p:lang(zh-TW), span:lang(zh-TW) {
   font-family: @zh-Hant;
 }
 
-.zh-HK {
+.zh-HK, body:lang(zh-HK), p:lang(zh-HK), span:lang(zh-HK) {
   font-family: @zh-HK;
 }


### PR DESCRIPTION
I think language families should automatically be applied to body, p, and span elements without forcing the user to manually add classes to them.  If the user sets the language for the document or a paragraph, they shouldn't also have to add a class to get the language family.