### PR TITLE
i18n Blockquote italics

### DIFF
--- a/Blitz_framework/LESS/base/typo.less
+++ b/Blitz_framework/LESS/base/typo.less
@@ -96,7 +96,7 @@ blockquote {
 
 blockquote p {
   text-indent: 0;
-  font-style: italic;
+  .italic;
 }
 
 blockquote p i,
@@ -124,7 +124,7 @@ abbr {
 }
 
 i, cite, dfn, em {
-  font-style: italic;
+  .italic;
 }
 
 /* Get back to normal when italic nested in italic */

--- a/Blitz_framework/LESS/reference/i18n.less
+++ b/Blitz_framework/LESS/reference/i18n.less
@@ -45,6 +45,8 @@
 
 /* Typography */
 
+/* If the language of the document needs another value for italic, modify the .italic mixin in utils/utilities.less. */
+
 .line-break-auto {
   -ms-line-break: auto;
   -webkit-line-break: auto;


### PR DESCRIPTION
Languages like Japanese don't usually use italics.  So, having blockquote assume italic is dangerous.

But, for English, most people probably want this.  I propose using the .italic mixin to set italic in all cases, and then making a note in i18n.less that people should change the mixin if they don't want the default behavior.  That way Blitz continues to work as it did before, but people can change one line of code if needed for their language.