### PR TITLE
End of Life (GH pages)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -245,9 +245,20 @@ p {}
 	font-weight: 500;
 }
 
+#status {
+  background-color: #DF0101;
+  color: #FFFFFF;
+  font-weight: 600;
+}
+
+#status a {
+  color: #FFFFFF;
+  font-weight: 700;
+}
+
 .lead-section {
 	text-align: center;
-	font-weight: 500;
+  font-weight: 500;
 }
 
 .secondary {

--- a/documentation/currentState.html
+++ b/documentation/currentState.html
@@ -27,15 +27,13 @@
 
     <section class="intro" id="doc-intro">
       <div class="wrapper">
-          <p>Published by Jiminy Panoz on February 14, 2020.</p>
+          <p>Published by Jiminy Panoz on July 1, 2020.</p>
 
-          <p>Updated on May 11, 2020 with a revised timeline.</p>
+          <p><strong>All repositories reached End Of Life on July 1, 2020. The Blitz project is no longer maintained and its repositories are read-only. You can still fork them if they can be useful to you.</strong></p>
 
-          <p>This page sums up what has been happening in the Blitz workspace for the current year.</p>
+          <p>This page sums up the last features implemented in 2020.</p>
 
           <p>For a 2019 overview, please check <a href="state2019.html">The State of Blitz in 2019.</a></p>
-
-          <p>2020 is the year we are sunsetting Blitz, and <strong>all repositories will reach End Of Life on July 1, 2020.</strong></p>
       </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 
   <p>Nope.</p>
 
-  <p>We sunset Blitz in 2020. See <a href="https://github.com/FriendsOfEpub/Blitz/issues/66">the meta issue in Blitz</a> for further details.</p>
+  <p>Blitz was sunset in 2020. As of July 1st, 2020 the entire project is no longer maintained and its repositories read-only. You can still fork them.</p>
 
   <p>We deemed Blitz feature-complete though, and it should consequently be still useful for a couple of years.</p>
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 
 <section id="status">
   <div class="wrapper">
-    <p class="lead-section">We are in the process of sunsetting Blitz and all repositories will reach End of Life on July 1, 2020. Check the <a href="documentation/currentState.html">The Current State of Blitz</a> for further details.</p>
+    <p class="lead-section">As of July 1, 2020 Blitz is no longer maintained.<br/> Check <a href="documentation/currentState.html">this page</a> for further details.</p>
   </div>
 </section>
 


### PR DESCRIPTION
This PR sunsets this repo. 

As of July 1st, 2020 the Blitz project is no longer maintained and its repositories become read-only. You can still fork the archived repos though.